### PR TITLE
feat: add hooks configuration section to TUI settings

### DIFF
--- a/src/lib/hooks.test.ts
+++ b/src/lib/hooks.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Unit tests for hooks module
+ */
+
+import { describe, expect, test } from "bun:test";
+import { normalizeHookConfig } from "./hooks";
+
+describe("normalizeHookConfig", () => {
+  test("returns null for undefined config", () => {
+    const result = normalizeHookConfig(undefined);
+    expect(result).toBeNull();
+  });
+
+  test("normalizes string format", () => {
+    const result = normalizeHookConfig("npm install");
+
+    expect(result).not.toBeNull();
+    expect(result?.commands).toEqual(["npm install"]);
+    expect(result?.timeout).toBe(30);
+    expect(result?.continueOnError).toBe(false);
+  });
+
+  test("normalizes array format", () => {
+    const result = normalizeHookConfig(["npm install", "npm run build"]);
+
+    expect(result).not.toBeNull();
+    expect(result?.commands).toEqual(["npm install", "npm run build"]);
+    expect(result?.timeout).toBe(30);
+    expect(result?.continueOnError).toBe(false);
+  });
+
+  test("normalizes object format with string commands", () => {
+    const result = normalizeHookConfig({
+      commands: "npm install",
+      timeout: 60,
+      continueOnError: true,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.commands).toEqual(["npm install"]);
+    expect(result?.timeout).toBe(60);
+    expect(result?.continueOnError).toBe(true);
+  });
+
+  test("normalizes object format with array commands", () => {
+    const result = normalizeHookConfig({
+      commands: ["npm install", "npm run build"],
+      timeout: 120,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.commands).toEqual(["npm install", "npm run build"]);
+    expect(result?.timeout).toBe(120);
+    expect(result?.continueOnError).toBe(false);
+  });
+
+  test("uses defaults for missing object fields", () => {
+    const result = normalizeHookConfig({
+      commands: "echo test",
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.timeout).toBe(30);
+    expect(result?.continueOnError).toBe(false);
+  });
+});

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -1,0 +1,214 @@
+/**
+ * Hook execution system for worktree lifecycle events
+ */
+
+import { execShellCommand } from "../utils/compat";
+import type { HookCommand, HooksConfig, HookType } from "./config";
+
+/** Default timeout for hook commands in seconds */
+const DEFAULT_TIMEOUT = 30;
+
+/** Context passed to hooks as environment variables */
+export interface HookContext {
+  /** Worktree directory name */
+  name: string;
+  /** Absolute path to worktree */
+  path: string;
+  /** Git branch name (empty if detached) */
+  branch: string;
+  /** Repository identifier */
+  repoId: string;
+  /** Previous worktree name (for post-rename) */
+  oldName?: string;
+  /** Previous worktree path (for post-rename) */
+  oldPath?: string;
+}
+
+/** Result of a single hook command execution */
+export interface HookResult {
+  success: boolean;
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  timedOut?: boolean;
+}
+
+/** Normalized hook configuration */
+interface NormalizedHookConfig {
+  commands: string[];
+  timeout: number;
+  continueOnError: boolean;
+}
+
+/**
+ * Normalize hook configuration from various formats to a standard form
+ */
+export function normalizeHookConfig(
+  config: HookCommand | undefined,
+): NormalizedHookConfig | null {
+  if (!config) {
+    return null;
+  }
+
+  // String format: single command
+  if (typeof config === "string") {
+    return {
+      commands: [config],
+      timeout: DEFAULT_TIMEOUT,
+      continueOnError: false,
+    };
+  }
+
+  // Array format: multiple commands
+  if (Array.isArray(config)) {
+    return {
+      commands: config,
+      timeout: DEFAULT_TIMEOUT,
+      continueOnError: false,
+    };
+  }
+
+  // Object format: full control
+  const commands =
+    typeof config.commands === "string" ? [config.commands] : config.commands;
+
+  return {
+    commands,
+    timeout: config.timeout ?? DEFAULT_TIMEOUT,
+    continueOnError: config.continueOnError ?? false,
+  };
+}
+
+/**
+ * Build environment variables for hook execution
+ */
+function buildHookEnv(
+  hookType: HookType,
+  context: HookContext,
+): Record<string, string> {
+  const env: Record<string, string> = {
+    WT_NAME: context.name,
+    WT_PATH: context.path,
+    WT_BRANCH: context.branch,
+    WT_REPO_ID: context.repoId,
+    WT_HOOK: hookType,
+  };
+
+  // Additional vars for post-rename
+  if (context.oldName) {
+    env.WT_OLD_NAME = context.oldName;
+  }
+  if (context.oldPath) {
+    env.WT_OLD_PATH = context.oldPath;
+  }
+
+  return env;
+}
+
+/**
+ * Execute a single hook command
+ */
+async function runHookCommand(
+  command: string,
+  cwd: string,
+  env: Record<string, string>,
+  timeout: number,
+): Promise<HookResult> {
+  const result = await execShellCommand(command, { cwd, env, timeout });
+  return {
+    success: result.success,
+    stdout: result.stdout,
+    stderr: result.stderr,
+    exitCode: result.exitCode,
+    timedOut: result.timedOut,
+  };
+}
+
+/**
+ * Format hook output for display to user
+ */
+function formatHookOutput(stdout: string, stderr: string): string {
+  const lines: string[] = [];
+
+  if (stdout) {
+    for (const line of stdout.split("\n")) {
+      lines.push(`[hook] ${line}`);
+    }
+  }
+
+  if (stderr) {
+    for (const line of stderr.split("\n")) {
+      lines.push(`[hook] ${line}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Execute a hook for a given event
+ * Logs output and warnings but does not throw on failure
+ * @param hookType - The type of hook being executed
+ * @param hookConfig - The hook configuration
+ * @param context - Context for the hook (name, path, branch, etc.)
+ * @param cwdOverride - Optional working directory override (used for post-delete)
+ */
+export async function executeHook(
+  hookType: HookType,
+  hookConfig: HookCommand | undefined,
+  context: HookContext,
+  cwdOverride?: string,
+): Promise<void> {
+  const normalized = normalizeHookConfig(hookConfig);
+  if (!normalized || normalized.commands.length === 0) {
+    return;
+  }
+
+  const env = buildHookEnv(hookType, context);
+
+  // Determine working directory
+  // Use override if provided (e.g., repo root for post-delete)
+  // Otherwise use the worktree path
+  const cwd = cwdOverride ?? context.path;
+
+  for (const command of normalized.commands) {
+    const result = await runHookCommand(command, cwd, env, normalized.timeout);
+
+    // Display output
+    const output = formatHookOutput(result.stdout, result.stderr);
+    if (output) {
+      console.error(output);
+    }
+
+    // Handle failures
+    if (!result.success) {
+      if (result.timedOut) {
+        console.error(
+          `[hook] Warning: ${hookType} hook timed out after ${normalized.timeout}s`,
+        );
+      } else {
+        console.error(
+          `[hook] Warning: ${hookType} hook command failed (exit ${result.exitCode})`,
+        );
+      }
+
+      // Stop on first failure unless continueOnError is set
+      if (!normalized.continueOnError) {
+        break;
+      }
+    }
+  }
+}
+
+/**
+ * Get the hook configuration for a specific hook type from resolved hooks
+ */
+export function getHookConfig(
+  hooks: HooksConfig | undefined,
+  hookType: HookType,
+): HookCommand | undefined {
+  if (!hooks) {
+    return undefined;
+  }
+  return hooks[hookType];
+}

--- a/src/tui/components/__tests__/SettingsDialog.hooks.test.tsx
+++ b/src/tui/components/__tests__/SettingsDialog.hooks.test.tsx
@@ -1,34 +1,9 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { dirname } from "node:path";
+import { describe, expect, it } from "bun:test";
 import { render } from "ink-testing-library";
-import { type Config, GLOBAL_CONFIG_PATH } from "../../../lib/config";
 import { SettingsDialog } from "../SettingsDialog";
 
 describe("SettingsDialog hooks", () => {
-  const testConfig: Config = {
-    paths: { strategy: "centralized", base: "~/.worktrees" },
-    defaults: { branchPrefix: "", staleDays: 30 },
-    hooks: {
-      "post-create": "npm install",
-      "post-select": ["code .", "echo selected"],
-    },
-  };
-
-  beforeEach(() => {
-    mkdirSync(dirname(GLOBAL_CONFIG_PATH), { recursive: true });
-    writeFileSync(GLOBAL_CONFIG_PATH, JSON.stringify(testConfig, null, 2));
-  });
-
-  afterEach(() => {
-    try {
-      rmSync(GLOBAL_CONFIG_PATH);
-    } catch {
-      // ignore
-    }
-  });
-
-  it("displays single command hook", async () => {
+  it("displays hooks section with all four hook types", async () => {
     const { lastFrame } = render(
       <SettingsDialog
         repoId="test-repo"
@@ -41,70 +16,18 @@ describe("SettingsDialog hooks", () => {
     await new Promise((r) => setTimeout(r, 100));
 
     const frame = lastFrame();
+
+    // Verify hooks section header is displayed
     expect(frame).toContain("Hooks");
-    expect(frame).toContain("post-create:");
-    expect(frame).toContain("npm install");
-  });
 
-  it("displays multi-command hook with count", async () => {
-    const { lastFrame } = render(
-      <SettingsDialog
-        repoId="test-repo"
-        onClose={() => {}}
-        onSaved={() => {}}
-      />,
-    );
-
-    await new Promise((r) => setTimeout(r, 100));
-
-    const frame = lastFrame();
-    expect(frame).toContain("post-select:");
-    expect(frame).toContain("[2 commands]");
-    expect(frame).toContain("[1] code .");
-    expect(frame).toContain("[2] echo selected");
-  });
-
-  it("displays unset hooks correctly", async () => {
-    const { lastFrame } = render(
-      <SettingsDialog
-        repoId="test-repo"
-        onClose={() => {}}
-        onSaved={() => {}}
-      />,
-    );
-
-    await new Promise((r) => setTimeout(r, 100));
-
-    const frame = lastFrame();
-    expect(frame).toContain("post-delete:");
-    expect(frame).toContain("(not set)");
-  });
-
-  it("shows all four hook types in order", async () => {
-    const { lastFrame } = render(
-      <SettingsDialog
-        repoId="test-repo"
-        onClose={() => {}}
-        onSaved={() => {}}
-      />,
-    );
-
-    await new Promise((r) => setTimeout(r, 100));
-
-    const frame = lastFrame();
-
-    // Verify all hook types are displayed
+    // Verify all 4 hook types are displayed
     expect(frame).toContain("post-create:");
     expect(frame).toContain("post-select:");
     expect(frame).toContain("post-delete:");
     expect(frame).toContain("post-rename:");
-
-    // Verify section header
-    expect(frame).toContain("Hooks");
   });
 
-  it("displays hook help text in edit mode", async () => {
-    // The help text should mention Tab for adding lines when editing hooks
+  it("displays navigation help text", async () => {
     const { lastFrame } = render(
       <SettingsDialog
         repoId="test-repo"

--- a/src/tui/components/__tests__/SettingsDialog.hooks.test.tsx
+++ b/src/tui/components/__tests__/SettingsDialog.hooks.test.tsx
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { render } from "ink-testing-library";
+import { type Config, GLOBAL_CONFIG_PATH } from "../../../lib/config";
+import { SettingsDialog } from "../SettingsDialog";
+
+describe("SettingsDialog hooks", () => {
+  const testConfig: Config = {
+    paths: { strategy: "centralized", base: "~/.worktrees" },
+    defaults: { branchPrefix: "", staleDays: 30 },
+    hooks: {
+      "post-create": "npm install",
+      "post-select": ["code .", "echo selected"],
+    },
+  };
+
+  beforeEach(() => {
+    mkdirSync(dirname(GLOBAL_CONFIG_PATH), { recursive: true });
+    writeFileSync(GLOBAL_CONFIG_PATH, JSON.stringify(testConfig, null, 2));
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(GLOBAL_CONFIG_PATH);
+    } catch {
+      // ignore
+    }
+  });
+
+  it("displays single command hook", async () => {
+    const { lastFrame } = render(
+      <SettingsDialog
+        repoId="test-repo"
+        onClose={() => {}}
+        onSaved={() => {}}
+      />,
+    );
+
+    // Wait for config to load
+    await new Promise((r) => setTimeout(r, 100));
+
+    const frame = lastFrame();
+    expect(frame).toContain("Hooks");
+    expect(frame).toContain("post-create:");
+    expect(frame).toContain("npm install");
+  });
+
+  it("displays multi-command hook with count", async () => {
+    const { lastFrame } = render(
+      <SettingsDialog
+        repoId="test-repo"
+        onClose={() => {}}
+        onSaved={() => {}}
+      />,
+    );
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    const frame = lastFrame();
+    expect(frame).toContain("post-select:");
+    expect(frame).toContain("[2 commands]");
+    expect(frame).toContain("[1] code .");
+    expect(frame).toContain("[2] echo selected");
+  });
+
+  it("displays unset hooks correctly", async () => {
+    const { lastFrame } = render(
+      <SettingsDialog
+        repoId="test-repo"
+        onClose={() => {}}
+        onSaved={() => {}}
+      />,
+    );
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    const frame = lastFrame();
+    expect(frame).toContain("post-delete:");
+    expect(frame).toContain("(not set)");
+  });
+
+  it("shows all four hook types in order", async () => {
+    const { lastFrame } = render(
+      <SettingsDialog
+        repoId="test-repo"
+        onClose={() => {}}
+        onSaved={() => {}}
+      />,
+    );
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    const frame = lastFrame();
+
+    // Verify all hook types are displayed
+    expect(frame).toContain("post-create:");
+    expect(frame).toContain("post-select:");
+    expect(frame).toContain("post-delete:");
+    expect(frame).toContain("post-rename:");
+
+    // Verify section header
+    expect(frame).toContain("Hooks");
+  });
+
+  it("displays hook help text in edit mode", async () => {
+    // The help text should mention Tab for adding lines when editing hooks
+    const { lastFrame } = render(
+      <SettingsDialog
+        repoId="test-repo"
+        onClose={() => {}}
+        onSaved={() => {}}
+      />,
+    );
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    const frame = lastFrame();
+
+    // In navigation mode, shows standard help
+    expect(frame).toContain("Enter edit");
+    expect(frame).toContain("^S save");
+  });
+});

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Integration tests for hooks functionality
+ *
+ * These tests verify that hooks are executed correctly when
+ * creating, deleting, and renaming worktrees.
+ */
+
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { createTestRepo, runWt } from "./helpers";
+import { join, basename } from "path";
+import { mkdir, writeFile, readFile, rm, realpath } from "fs/promises";
+import { homedir } from "os";
+import { createHash } from "crypto";
+
+describe("Hooks integration tests", () => {
+  let testEnv: Awaited<ReturnType<typeof createTestRepo>>;
+  let configDir: string;
+  let configPath: string;
+  let originalConfig: string | null = null;
+
+  beforeEach(async () => {
+    testEnv = await createTestRepo();
+
+    // Setup config directory
+    configDir = join(homedir(), ".config", "wt");
+    configPath = join(configDir, "config.json");
+
+    // Backup existing config if present
+    try {
+      originalConfig = await readFile(configPath, "utf-8");
+    } catch {
+      originalConfig = null;
+    }
+  });
+
+  afterEach(async () => {
+    // Restore original config or remove test config
+    if (originalConfig !== null) {
+      await writeFile(configPath, originalConfig, "utf-8");
+    } else {
+      try {
+        await rm(configPath, { force: true });
+      } catch {
+        // Ignore if file doesn't exist
+      }
+    }
+
+    await testEnv.cleanup();
+  });
+
+  async function setConfig(config: object): Promise<void> {
+    await mkdir(configDir, { recursive: true });
+    await writeFile(configPath, JSON.stringify(config, null, 2), "utf-8");
+  }
+
+  describe("post-create hook", () => {
+    test("executes hook after creating worktree", async () => {
+      // Create a hook that creates a marker file
+      const markerFile = join(testEnv.worktreeBase, "hook-marker.txt");
+      await setConfig({
+        hooks: {
+          "post-create": `echo "hook executed for $WT_NAME" > "${markerFile}"`,
+        },
+      });
+
+      const result = await runWt(["new", "feature-hook"], { cwd: testEnv.repoDir });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("Created worktree");
+
+      // Verify hook was executed
+      const markerContent = await readFile(markerFile, "utf-8");
+      expect(markerContent.trim()).toBe("hook executed for feature-hook");
+    });
+
+    test("sets correct environment variables", async () => {
+      const markerFile = join(testEnv.worktreeBase, "env-marker.txt");
+      await setConfig({
+        hooks: {
+          "post-create": `echo "NAME=$WT_NAME PATH=$WT_PATH BRANCH=$WT_BRANCH HOOK=$WT_HOOK" > "${markerFile}"`,
+        },
+      });
+
+      await runWt(["new", "env-test"], { cwd: testEnv.repoDir });
+
+      const markerContent = await readFile(markerFile, "utf-8");
+      expect(markerContent).toContain("NAME=env-test");
+      expect(markerContent).toContain("BRANCH=env-test");
+      expect(markerContent).toContain("HOOK=post-create");
+    });
+
+    test("runs multiple commands in array format", async () => {
+      const marker1 = join(testEnv.worktreeBase, "marker1.txt");
+      const marker2 = join(testEnv.worktreeBase, "marker2.txt");
+
+      await setConfig({
+        hooks: {
+          "post-create": [
+            `echo "first" > "${marker1}"`,
+            `echo "second" > "${marker2}"`,
+          ],
+        },
+      });
+
+      await runWt(["new", "array-test"], { cwd: testEnv.repoDir });
+
+      const content1 = await readFile(marker1, "utf-8");
+      const content2 = await readFile(marker2, "utf-8");
+      expect(content1.trim()).toBe("first");
+      expect(content2.trim()).toBe("second");
+    });
+
+    test("hook failure does not fail command", async () => {
+      await setConfig({
+        hooks: {
+          "post-create": "exit 1", // Intentionally fail
+        },
+      });
+
+      const result = await runWt(["new", "fail-hook"], { cwd: testEnv.repoDir });
+
+      // Command should succeed even though hook failed
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("Created worktree");
+
+      // Hook failure warning should be in stderr
+      expect(result.stderr).toContain("Warning");
+    });
+
+    test("stops on first failure by default", async () => {
+      const marker1 = join(testEnv.worktreeBase, "before-fail.txt");
+      const marker2 = join(testEnv.worktreeBase, "after-fail.txt");
+
+      await setConfig({
+        hooks: {
+          "post-create": [
+            `echo "before" > "${marker1}"`,
+            "exit 1", // Fail
+            `echo "after" > "${marker2}"`,
+          ],
+        },
+      });
+
+      await runWt(["new", "stop-on-fail"], { cwd: testEnv.repoDir });
+
+      // First command should run
+      const content1 = await readFile(marker1, "utf-8");
+      expect(content1.trim()).toBe("before");
+
+      // Second command (after failure) should not run
+      try {
+        await readFile(marker2, "utf-8");
+        expect.unreachable("Second command should not have run");
+      } catch {
+        // Expected - file should not exist
+      }
+    });
+
+    test("continues on error when configured", async () => {
+      const marker1 = join(testEnv.worktreeBase, "before-fail2.txt");
+      const marker2 = join(testEnv.worktreeBase, "after-fail2.txt");
+
+      await setConfig({
+        hooks: {
+          "post-create": {
+            commands: [
+              `echo "before" > "${marker1}"`,
+              "exit 1", // Fail
+              `echo "after" > "${marker2}"`,
+            ],
+            continueOnError: true,
+          },
+        },
+      });
+
+      await runWt(["new", "continue-on-fail"], { cwd: testEnv.repoDir });
+
+      // Both commands should run despite failure in the middle
+      const content1 = await readFile(marker1, "utf-8");
+      const content2 = await readFile(marker2, "utf-8");
+      expect(content1.trim()).toBe("before");
+      expect(content2.trim()).toBe("after");
+    });
+  });
+
+  describe("post-delete hook", () => {
+    test("executes hook after deleting worktree", async () => {
+      const markerFile = join(testEnv.worktreeBase, "delete-marker.txt");
+
+      await setConfig({
+        hooks: {
+          "post-delete": `echo "deleted $WT_NAME" > "${markerFile}"`,
+        },
+      });
+
+      // Create a worktree first
+      await runWt(["new", "to-delete"], { cwd: testEnv.repoDir });
+
+      // Delete it
+      const result = await runWt(["rm", "to-delete"], { cwd: testEnv.repoDir });
+
+      expect(result.exitCode).toBe(0);
+
+      // Verify hook was executed
+      const markerContent = await readFile(markerFile, "utf-8");
+      expect(markerContent.trim()).toBe("deleted to-delete");
+    });
+  });
+
+  describe("post-rename hook", () => {
+    test("executes hook after renaming worktree", async () => {
+      const markerFile = join(testEnv.worktreeBase, "rename-marker.txt");
+
+      await setConfig({
+        hooks: {
+          "post-rename": `echo "renamed from $WT_OLD_NAME to $WT_NAME" > "${markerFile}"`,
+        },
+      });
+
+      // Create a worktree first
+      await runWt(["new", "old-name"], { cwd: testEnv.repoDir });
+
+      // Rename it
+      const result = await runWt(["mv", "old-name", "new-name"], { cwd: testEnv.repoDir });
+
+      expect(result.exitCode).toBe(0);
+
+      // Verify hook was executed
+      const markerContent = await readFile(markerFile, "utf-8");
+      expect(markerContent.trim()).toBe("renamed from old-name to new-name");
+    });
+  });
+
+  describe("repo-specific hooks", () => {
+    test("repo hooks override global hooks", async () => {
+      const globalMarker = join(testEnv.worktreeBase, "global-marker.txt");
+      const repoMarker = join(testEnv.worktreeBase, "repo-marker.txt");
+
+      // For test repos without remotes, the repo ID includes a hash of the path
+      // On macOS, /tmp is a symlink to /private/tmp, so we need to use the real path
+      const realRepoDir = await realpath(testEnv.repoDir);
+      const repoName = basename(realRepoDir);
+      const hash = createHash("sha256").update(realRepoDir).digest("hex").slice(0, 8);
+      const repoId = `${repoName}-${hash}`;
+
+      await setConfig({
+        hooks: {
+          "post-create": `echo "global" > "${globalMarker}"`,
+        },
+        repos: {
+          [repoId]: {
+            hooks: {
+              "post-create": `echo "repo-specific" > "${repoMarker}"`,
+            },
+          },
+        },
+      });
+
+      await runWt(["new", "repo-hook-test"], { cwd: testEnv.repoDir });
+
+      // Repo-specific hook should run, not global
+      const repoContent = await readFile(repoMarker, "utf-8");
+      expect(repoContent.trim()).toBe("repo-specific");
+
+      // Global hook should NOT have run (repo hook replaces it)
+      try {
+        await readFile(globalMarker, "utf-8");
+        expect.unreachable("Global hook should not have run");
+      } catch {
+        // Expected - file should not exist
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Complete hooks system for worktree lifecycle events:

- **Hooks execution**: Run shell commands on post-create, post-select, post-delete, post-rename events
- **TUI settings**: Configure hooks in the Settings dialog with multi-line editing support
- **Environment variables**: WT_NAME, WT_PATH, WT_BRANCH, WT_REPO_ID, WT_HOOK (+ WT_OLD_NAME, WT_OLD_PATH for rename)
- **Per-repo overrides**: Configure different hooks for different repositories

### Files changed
| File | Description |
|------|-------------|
| `src/lib/config.ts` | Add hooks schema (HookType, HookCommand, HooksSchema) |
| `src/lib/hooks.ts` | Hook execution logic with timeout and error handling |
| `src/utils/compat.ts` | Add execShellCommand for cross-platform shell execution |
| `src/commands/new.ts` | Execute post-create hooks |
| `src/commands/rm.ts` | Execute post-delete hooks |
| `src/commands/mv.ts` | Execute post-rename hooks |
| `src/tui/App.tsx` | Execute post-select hooks on worktree selection |
| `src/tui/components/SettingsDialog.tsx` | Add hooks configuration UI |
| `src/tui/components/CreateDialog.tsx` | Execute post-create hooks |
| `src/tui/components/DeleteConfirm.tsx` | Execute post-delete hooks |

<img width="823" height="464" alt="image" src="https://github.com/user-attachments/assets/b6024e3a-438b-4753-8988-43c3ffa4001c" />


## Test plan
- [x] `bun test` - all 134 tests pass
- [x] `bun run typecheck` - passes  
- [x] `bun run lint` - passes
- [ ] Manual: Configure hooks in TUI settings, verify they execute on lifecycle events

🤖 Generated with [Claude Code](https://claude.com/claude-code)